### PR TITLE
fix(ci): use stable semantic-release version and Git tag versioning

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Python Semantic Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v9.21.1
+        uses: python-semantic-release/python-semantic-release@v9.14.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_committer_name: "semantic-release"
@@ -55,9 +55,11 @@ jobs:
       - name: Get version info
         id: get_version
         run: |
-          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          # Get the latest tag (version) from Git
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          VERSION=${LATEST_TAG#v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
 
       - name: Summary
         run: |

--- a/asciiapp/views.py
+++ b/asciiapp/views.py
@@ -4,10 +4,12 @@ from .cowboy import render_art, ASCII_ARTS
 
 JOKES = [
     "Pod went missing—turned out to be a Job all along.",
-    "Our cowboy lassoed nodes; now it’s a proper cluster.",
+    "Our cowboy lassoed nodes; now it's a proper cluster.",
     "This Service had no selectors, but plenty of ambition.",
     "Yeehaw! Autoscaler grew faster than our Helm chart broke.",
     "ConfigMaps: because even cowboys need plain text wisdom.",
+    "This cowboy's Ingress was denied—guess the Load Balancer wasn't feeling social!",
+    "Kubernetes volumes mounted faster than my horse at sunrise.",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cowboy-django"
-version = "2.0.3"
+dynamic = ["version"]
 description = "A Django + HTMX web app that serves ASCII art cowboys with Kubernetes-themed jokes"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,17 +18,23 @@ dev = [
     "python-semantic-release>=9.0.0",
 ]
 
+[build-system]
+requires = ["setuptools>=61", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["cowboysite", "asciiapp"]
+
+[tool.setuptools_scm]
+
 [tool.semantic_release]
-version_toml = [
-    "pyproject.toml:project.version",
-]
 build_command = """
     python -m pip install -e '.[build]'
     uv lock --upgrade-package cowboy-django
-    git add uv.lock
 """
 major_on_zero = false
 tag_format = "v{version}"
+commit = false
 
 [tool.semantic_release.branches.main]
 match = "main"

--- a/uv.lock
+++ b/uv.lock
@@ -119,35 +119,8 @@ wheels = [
 ]
 
 [[package]]
-name = "deprecated"
-version = "1.2.18"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744, upload-time = "2025-01-27T10:46:25.7Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998, upload-time = "2025-01-27T10:46:09.186Z" },
-]
-
-[[package]]
-name = "django"
-version = "5.2.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref" },
-    { name = "sqlparse" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/62/9b/779f853c3d2d58b9e08346061ff3e331cdec3fe3f53aae509e256412a593/django-5.2.5.tar.gz", hash = "sha256:0745b25681b129a77aae3d4f6549b62d3913d74407831abaa0d9021a03954bae", size = 10859748, upload-time = "2025-08-06T08:26:29.978Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/6e/98a1d23648e0085bb5825326af17612ecd8fc76be0ce96ea4dc35e17b926/django-5.2.5-py3-none-any.whl", hash = "sha256:2b2ada0ee8a5ff743a40e2b9820d1f8e24c11bac9ae6469cd548f0057ea6ddcd", size = 8302999, upload-time = "2025-08-06T08:26:23.562Z" },
-]
-
-[[package]]
-name = "django-cowboy-htmx-rotator"
-version = "1.0.0"
-source = { virtual = "." }
+name = "cowboy-django"
+source = { editable = "." }
 dependencies = [
     { name = "django" },
     { name = "uvicorn", extra = ["standard"] },
@@ -176,6 +149,32 @@ provides-extras = ["build"]
 dev = [
     { name = "python-semantic-release", specifier = ">=9.0.0" },
     { name = "ruff", specifier = ">=0.12.9" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744, upload-time = "2025-01-27T10:46:25.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998, upload-time = "2025-01-27T10:46:09.186Z" },
+]
+
+[[package]]
+name = "django"
+version = "5.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/9b/779f853c3d2d58b9e08346061ff3e331cdec3fe3f53aae509e256412a593/django-5.2.5.tar.gz", hash = "sha256:0745b25681b129a77aae3d4f6549b62d3913d74407831abaa0d9021a03954bae", size = 10859748, upload-time = "2025-08-06T08:26:29.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/6e/98a1d23648e0085bb5825326af17612ecd8fc76be0ce96ea4dc35e17b926/django-5.2.5-py3-none-any.whl", hash = "sha256:2b2ada0ee8a5ff743a40e2b9820d1f8e24c11bac9ae6469cd548f0057ea6ddcd", size = 8302999, upload-time = "2025-08-06T08:26:23.562Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Downgrade to python-semantic-release@v9.14.0 for stability (from v9.21.1)
- Fix version detection to use Git tags instead of reading pyproject.toml 
- Aligns with our setuptools_scm Git tag-based approach following Django versioning principles

## Problem Solved
The previous version (v9.21.1) was failing during Docker container build for the Action itself. This stable version should resolve those issues.

## Django Versioning Alignment
✅ Main branch: Clean releases (v1.0.0, v1.1.0)  
✅ Develop branch: Alpha pre-releases (v1.1.0a1, v1.1.0a2)  
✅ Git tags only: No version files, pure Git tag discovery  
✅ No version commits: Keeps develop/main synchronized  

## Test plan
- [ ] Semantic-release workflow runs successfully on develop
- [ ] Creates proper alpha pre-release (e.g., v2.1.0a1)
- [ ] Docker workflow triggers after semantic-release
- [ ] No extra commits created on develop branch

🤖 Generated with [Claude Code](https://claude.ai/code)