### PR TITLE
feat: release v2.1.0 with Git tag-based versioning

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Python Semantic Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v9.21.1
+        uses: python-semantic-release/python-semantic-release@v9.14.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_committer_name: "semantic-release"
@@ -55,9 +55,11 @@ jobs:
       - name: Get version info
         id: get_version
         run: |
-          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          # Get the latest tag (version) from Git
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          VERSION=${LATEST_TAG#v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
 
       - name: Summary
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,51 @@
 # CHANGELOG
 
 
+## v2.1.0-a.1 (2025-08-17)
+
+### Bug Fixes
+
+- **project**: Correct project name from django-cowboy-htmx-rotator to cowboy-django
+  ([`727fc67`](https://github.com/dkdndes/cowboy-django/commit/727fc677d0afe8db928f081660e6292a330f55e1))
+
+- Update pyproject.toml project name to match repository name - Fix build command package name
+  reference - No circular reference issues - version is static string updated by semantic-release
+
+### Features
+
+- **jokes**: Add two new Kubernetes-themed cowboy jokes
+  ([`7e2cfca`](https://github.com/dkdndes/cowboy-django/commit/7e2cfcaba810209001b1b9bf06d7c2a9773f6ae4))
+
+- Add Load Balancer/Ingress joke about denied access - Add volumes mounting joke with cowboy horse
+  metaphor - Improves humor variety in the rotation system
+
+- **version**: Implement dynamic versioning without git commits
+  ([`575c99e`](https://github.com/dkdndes/cowboy-django/commit/575c99e46ab57240243c89cc437af09042d6d4f3))
+
+- Use setuptools_scm for automatic version from git tags - Remove version_toml to prevent
+  semantic-release version commits - Set commit=false to avoid extra commits on main branch - Add
+  dynamic version import in cowboysite/__init__.py - Ignore auto-generated _version.py file
+
+This eliminates the merge conflict issue where main gets extra commits after each release, keeping
+  develop and main in sync.
+
+- **version**: Use Git tags for versioning without file commits
+  ([#27](https://github.com/dkdndes/cowboy-django/pull/27),
+  [`df8c6ab`](https://github.com/dkdndes/cowboy-django/commit/df8c6ab28e9ba695a91050854e6033f4be51cdac))
+
+- Remove static version from pyproject.toml, use dynamic versioning - Configure setuptools_scm for
+  Git tag-based version discovery - Set semantic-release commit=false to avoid version bump commits
+  - Add setuptools package discovery for Django app structure - Include both new Kubernetes cowboy
+  jokes in views.py
+
+This eliminates the circular reference issue and prevents extra commits on main branch after
+  releases, keeping develop and main branches synchronized.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-authored-by: Claude <noreply@anthropic.com>
+
+
 ## v2.0.3 (2025-08-16)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,43 @@
 # CHANGELOG
 
 
+## v2.1.0-a.2 (2025-08-17)
+
+### Bug Fixes
+
+- **ci**: Use stable semantic-release version and Git tag versioning
+  ([#28](https://github.com/dkdndes/cowboy-django/pull/28),
+  [`3dbcb9f`](https://github.com/dkdndes/cowboy-django/commit/3dbcb9fe6595391ca822336c2744cec58331abc6))
+
+* feat(version): use Git tags for versioning without file commits
+
+- Remove static version from pyproject.toml, use dynamic versioning - Configure setuptools_scm for
+  Git tag-based version discovery - Set semantic-release commit=false to avoid version bump commits
+  - Add setuptools package discovery for Django app structure - Include both new Kubernetes cowboy
+  jokes in views.py
+
+This eliminates the circular reference issue and prevents extra commits on main branch after
+  releases, keeping develop and main branches synchronized.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+* fix(ci): use stable semantic-release version and Git tag versioning
+
+- Downgrade to python-semantic-release@v9.14.0 for stability - Fix version detection to use Git tags
+  instead of pyproject.toml - This aligns with our setuptools_scm Git tag-based approach - Should
+  resolve Docker container build issues in the Action
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+---------
+
+Co-authored-by: Claude <noreply@anthropic.com>
+
+
 ## v2.1.0-a.1 (2025-08-17)
 
 ### Bug Fixes
@@ -12,22 +49,6 @@
   reference - No circular reference issues - version is static string updated by semantic-release
 
 ### Features
-
-- **jokes**: Add two new Kubernetes-themed cowboy jokes
-  ([`7e2cfca`](https://github.com/dkdndes/cowboy-django/commit/7e2cfcaba810209001b1b9bf06d7c2a9773f6ae4))
-
-- Add Load Balancer/Ingress joke about denied access - Add volumes mounting joke with cowboy horse
-  metaphor - Improves humor variety in the rotation system
-
-- **version**: Implement dynamic versioning without git commits
-  ([`575c99e`](https://github.com/dkdndes/cowboy-django/commit/575c99e46ab57240243c89cc437af09042d6d4f3))
-
-- Use setuptools_scm for automatic version from git tags - Remove version_toml to prevent
-  semantic-release version commits - Set commit=false to avoid extra commits on main branch - Add
-  dynamic version import in cowboysite/__init__.py - Ignore auto-generated _version.py file
-
-This eliminates the merge conflict issue where main gets extra commits after each release, keeping
-  develop and main in sync.
 
 - **version**: Use Git tags for versioning without file commits
   ([#27](https://github.com/dkdndes/cowboy-django/pull/27),
@@ -44,6 +65,22 @@ This eliminates the circular reference issue and prevents extra commits on main 
 🤖 Generated with [Claude Code](https://claude.ai/code)
 
 Co-authored-by: Claude <noreply@anthropic.com>
+
+- **jokes**: Add two new Kubernetes-themed cowboy jokes
+  ([`7e2cfca`](https://github.com/dkdndes/cowboy-django/commit/7e2cfcaba810209001b1b9bf06d7c2a9773f6ae4))
+
+- Add Load Balancer/Ingress joke about denied access - Add volumes mounting joke with cowboy horse
+  metaphor - Improves humor variety in the rotation system
+
+- **version**: Implement dynamic versioning without git commits
+  ([`575c99e`](https://github.com/dkdndes/cowboy-django/commit/575c99e46ab57240243c89cc437af09042d6d4f3))
+
+- Use setuptools_scm for automatic version from git tags - Remove version_toml to prevent
+  semantic-release version commits - Set commit=false to avoid extra commits on main branch - Add
+  dynamic version import in cowboysite/__init__.py - Ignore auto-generated _version.py file
+
+This eliminates the merge conflict issue where main gets extra commits after each release, keeping
+  develop and main in sync.
 
 
 ## v2.0.3 (2025-08-16)
@@ -107,6 +144,12 @@ Use known working versions instead of latest to fix the load-parser-config error
 
 This should resolve the parser function compatibility issue.
 
+- **ci**: Use default conventionalcommits rules to avoid parser errors
+  ([`cbcd3f5`](https://github.com/dkdndes/cowboy-django/commit/cbcd3f55e02c47326585ebf1212ed7545b22cfe6))
+
+Remove custom releaseRules that were causing semantic-release parser failures. Use default
+  conventionalcommits behavior which should handle feat/fix correctly.
+
 - **ci**: Remove problematic parserOpts from semantic-release config
   ([`177d4da`](https://github.com/dkdndes/cowboy-django/commit/177d4da7e748f7990c1c0903ecdf3232ce0d176d))
 
@@ -123,12 +166,6 @@ The parserOpts configuration was causing a parsing error in semantic-release. Us
   comprehensive CLAUDE.md documentation for future development
 
 This makes the release workflow portable to any Django project.
-
-- **ci**: Use default conventionalcommits rules to avoid parser errors
-  ([`cbcd3f5`](https://github.com/dkdndes/cowboy-django/commit/cbcd3f55e02c47326585ebf1212ed7545b22cfe6))
-
-Remove custom releaseRules that were causing semantic-release parser failures. Use default
-  conventionalcommits behavior which should handle feat/fix correctly.
 
 - **ignore**: Resolve .gitignore conflict and exclude CLAUDE.md from tracking
   ([`4332da8`](https://github.com/dkdndes/cowboy-django/commit/4332da86cd24d5a348ca598832df237b13b063f5))
@@ -147,10 +184,6 @@ Remove custom releaseRules that were causing semantic-release parser failures. U
   based on feat commits
 
 BREAKING CHANGE: This enables real releases instead of dry-run mode
-
-### Breaking Changes
-
-- **release**: This enables real releases instead of dry-run mode
 
 
 ## v1.2.1 (2025-08-16)
@@ -222,6 +255,12 @@ This makes the release workflow portable to any Django project.
 
 ### Chores
 
+- **lockfile**: Update package-lock.json for semantic-release setup
+  ([`0f13f56`](https://github.com/dkdndes/cowboy-django/commit/0f13f56d17770d3ab4e07867b6318190b331c12d))
+
+- **deps**: Add semantic-release toolchain and config to package.json
+  ([`cab5ac1`](https://github.com/dkdndes/cowboy-django/commit/cab5ac15317ba0632454d331b2803a1a6baeab45))
+
 - Ignore node_modules
   ([`7464c14`](https://github.com/dkdndes/cowboy-django/commit/7464c14eb95161fb90fb84e5268810c20a3ccb40))
 
@@ -233,12 +272,6 @@ Signed-off-by: PR <dkdndes@gmail.com>
 - Ruff fix and ruff format
   ([`8d4ceae`](https://github.com/dkdndes/cowboy-django/commit/8d4ceae7c49336e3c7f35bcabc4b0b4fa5e4de83))
 
-- **deps**: Add semantic-release toolchain and config to package.json
-  ([`cab5ac1`](https://github.com/dkdndes/cowboy-django/commit/cab5ac15317ba0632454d331b2803a1a6baeab45))
-
-- **lockfile**: Update package-lock.json for semantic-release setup
-  ([`0f13f56`](https://github.com/dkdndes/cowboy-django/commit/0f13f56d17770d3ab4e07867b6318190b331c12d))
-
 ### Documentation
 
 - Ignore nodes_moduls
@@ -248,12 +281,6 @@ Signed-off-by: PR <dkdndes@gmail.com>
   ([`778fa8b`](https://github.com/dkdndes/cowboy-django/commit/778fa8b930851068db649c27d6916def4ed1b105))
 
 ### Features
-
-- **ci**: Add local dry-run release workflow for act testing
-  ([`0a1ca1d`](https://github.com/dkdndes/cowboy-django/commit/0a1ca1d7fdb77cb70a3b74ac52337a36a315b1f7))
-
-- **ci**: Add release workflow for develop and main
-  ([`b0fecc5`](https://github.com/dkdndes/cowboy-django/commit/b0fecc5e87641ad798ff3afe39b3e03105463011))
 
 - **release**: Migrate from Node.js to Python semantic-release
   ([#22](https://github.com/dkdndes/cowboy-django/pull/22),
@@ -274,10 +301,19 @@ The parserOpts configuration was causing a parsing error in semantic-release. Us
 This replaces the problematic Node.js semantic-release with the Python version that's more
   appropriate for our Django project.
 
+- **ci**: Add local dry-run release workflow for act testing
+  ([`0a1ca1d`](https://github.com/dkdndes/cowboy-django/commit/0a1ca1d7fdb77cb70a3b74ac52337a36a315b1f7))
+
+- **ci**: Add release workflow for develop and main
+  ([`b0fecc5`](https://github.com/dkdndes/cowboy-django/commit/b0fecc5e87641ad798ff3afe39b3e03105463011))
+
 
 ## v1.0.0 (2025-08-14)
 
 ### Documentation
+
+- Update issue templates
+  ([`e9a0df3`](https://github.com/dkdndes/cowboy-django/commit/e9a0df3c449d928b05aeb10ea48f2499bbb09347))
 
 - Add comprehensive documentation and MIT license
   ([`b9a4064`](https://github.com/dkdndes/cowboy-django/commit/b9a406415988817bf31a89f7019e41333eff5cb1))
@@ -286,24 +322,10 @@ This replaces the problematic Node.js semantic-release with the Python version t
   Detailed Kubernetes deployment workflow - Project structure and technical highlights - MIT license
   for open source distribution - Future extension roadmap
 
-- Update issue templates
-  ([`e9a0df3`](https://github.com/dkdndes/cowboy-django/commit/e9a0df3c449d928b05aeb10ea48f2499bbb09347))
-
 ### Features
 
-- Add core Django application with ASCII cowboy jokes
-  ([`13d84ef`](https://github.com/dkdndes/cowboy-django/commit/13d84ef3364e3f1498256da573e04f16c1061327))
-
-- Django 5.0+ application with HTMX frontend - ASCII art cowboys with Kubernetes-themed humor -
-  JSON-based ASCII art storage (prevents Python syntax issues) - Session-based joke/art rotation
-  system - Modern uv dependency management - Dark theme responsive design
-
-- Add Docker containerization with uv
-  ([`b09c7c7`](https://github.com/dkdndes/cowboy-django/commit/b09c7c7ea3eb7ab3914d5242e11c1de53988ec0d))
-
-- Multi-stage Docker build optimized for production - Modern uv dependency management integration -
-  Proper .dockerignore for optimized build context - ASGI/Uvicorn server configuration - Container
-  runs on port 8000
+- Comprehensive readme
+  ([`899cc46`](https://github.com/dkdndes/cowboy-django/commit/899cc4612040d65841e073343128a7c1c6608ab7))
 
 - Add Kubernetes deployment manifests
   ([`f10505b`](https://github.com/dkdndes/cowboy-django/commit/f10505b82c2abea757489cc604f66aca971d29f0))
@@ -312,5 +334,16 @@ This replaces the problematic Node.js semantic-release with the Python version t
   migrations - ClusterIP service configuration - Resource limits and requests - Example nginx
   deployment for testing - Production-ready cowboy namespace setup
 
-- Comprehensive readme
-  ([`899cc46`](https://github.com/dkdndes/cowboy-django/commit/899cc4612040d65841e073343128a7c1c6608ab7))
+- Add Docker containerization with uv
+  ([`b09c7c7`](https://github.com/dkdndes/cowboy-django/commit/b09c7c7ea3eb7ab3914d5242e11c1de53988ec0d))
+
+- Multi-stage Docker build optimized for production - Modern uv dependency management integration -
+  Proper .dockerignore for optimized build context - ASGI/Uvicorn server configuration - Container
+  runs on port 8000
+
+- Add core Django application with ASCII cowboy jokes
+  ([`13d84ef`](https://github.com/dkdndes/cowboy-django/commit/13d84ef3364e3f1498256da573e04f16c1061327))
+
+- Django 5.0+ application with HTMX frontend - ASCII art cowboys with Kubernetes-themed humor -
+  JSON-based ASCII art storage (prevents Python syntax issues) - Session-based joke/art rotation
+  system - Modern uv dependency management - Dark theme responsive design

--- a/asciiapp/views.py
+++ b/asciiapp/views.py
@@ -4,10 +4,12 @@ from .cowboy import render_art, ASCII_ARTS
 
 JOKES = [
     "Pod went missing—turned out to be a Job all along.",
-    "Our cowboy lassoed nodes; now it’s a proper cluster.",
+    "Our cowboy lassoed nodes; now it's a proper cluster.",
     "This Service had no selectors, but plenty of ambition.",
     "Yeehaw! Autoscaler grew faster than our Helm chart broke.",
     "ConfigMaps: because even cowboys need plain text wisdom.",
+    "This cowboy's Ingress was denied—guess the Load Balancer wasn't feeling social!",
+    "Kubernetes volumes mounted faster than my horse at sunrise.",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,19 +22,17 @@ dev = [
 requires = ["setuptools>=61", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+packages = ["cowboysite", "asciiapp"]
+
 [tool.setuptools_scm]
-write_to = "cowboysite/_version.py"
 
 [tool.semantic_release]
-# Don't update version files to avoid extra commits
-# version_toml = [
-#     "pyproject.toml:project.version",
-# ]
 build_command = """
     python -m pip install -e '.[build]'
     uv lock --upgrade-package cowboy-django
 """
-commit = false  # Don't create version bump commits
+commit = false
 major_on_zero = false
 tag_format = "v{version}"
 

--- a/uv.lock
+++ b/uv.lock
@@ -119,35 +119,8 @@ wheels = [
 ]
 
 [[package]]
-name = "deprecated"
-version = "1.2.18"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744, upload-time = "2025-01-27T10:46:25.7Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998, upload-time = "2025-01-27T10:46:09.186Z" },
-]
-
-[[package]]
-name = "django"
-version = "5.2.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref" },
-    { name = "sqlparse" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/62/9b/779f853c3d2d58b9e08346061ff3e331cdec3fe3f53aae509e256412a593/django-5.2.5.tar.gz", hash = "sha256:0745b25681b129a77aae3d4f6549b62d3913d74407831abaa0d9021a03954bae", size = 10859748, upload-time = "2025-08-06T08:26:29.978Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/6e/98a1d23648e0085bb5825326af17612ecd8fc76be0ce96ea4dc35e17b926/django-5.2.5-py3-none-any.whl", hash = "sha256:2b2ada0ee8a5ff743a40e2b9820d1f8e24c11bac9ae6469cd548f0057ea6ddcd", size = 8302999, upload-time = "2025-08-06T08:26:23.562Z" },
-]
-
-[[package]]
-name = "django-cowboy-htmx-rotator"
-version = "1.0.0"
-source = { virtual = "." }
+name = "cowboy-django"
+source = { editable = "." }
 dependencies = [
     { name = "django" },
     { name = "uvicorn", extra = ["standard"] },
@@ -176,6 +149,32 @@ provides-extras = ["build"]
 dev = [
     { name = "python-semantic-release", specifier = ">=9.0.0" },
     { name = "ruff", specifier = ">=0.12.9" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744, upload-time = "2025-01-27T10:46:25.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998, upload-time = "2025-01-27T10:46:09.186Z" },
+]
+
+[[package]]
+name = "django"
+version = "5.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/9b/779f853c3d2d58b9e08346061ff3e331cdec3fe3f53aae509e256412a593/django-5.2.5.tar.gz", hash = "sha256:0745b25681b129a77aae3d4f6549b62d3913d74407831abaa0d9021a03954bae", size = 10859748, upload-time = "2025-08-06T08:26:29.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/6e/98a1d23648e0085bb5825326af17612ecd8fc76be0ce96ea4dc35e17b926/django-5.2.5-py3-none-any.whl", hash = "sha256:2b2ada0ee8a5ff743a40e2b9820d1f8e24c11bac9ae6469cd548f0057ea6ddcd", size = 8302999, upload-time = "2025-08-06T08:26:23.562Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR demonstrates our improved Django-style versioning approach:

✅ **Git tag-based versioning** (setuptools_scm)  
✅ **No version commits** (semantic-release commit=false)  
✅ **Django-style pre-releases** (v2.1.0-a.2 → v2.1.0)  
✅ **Clean main releases** (no dev/alpha suffixes)  

## Changes from develop
- New Kubernetes cowboy jokes added  
- Git tag-based versioning implementation  
- Stable python-semantic-release@v9.14.0  
- Proper setuptools configuration for Django apps  

## Expected Results
- ✅ Main branch gets clean `v2.1.0` release  
- ✅ Docker images built for `latest` tag  
- ✅ No extra version commits created  
- ✅ Develop and main stay synchronized  

## Version History  
- `v2.0.3` (last main release)  
- `v2.1.0-a.1`, `v2.1.0-a.2` (develop alphas)  
- `v2.1.0` (this release - promote alpha to stable)  

This follows Django's release process principles perfectly.

🤖 Generated with [Claude Code](https://claude.ai/code)